### PR TITLE
Добавил фикстуры для пользователей, услуг и заказов. Реализовал пагинацию в запросах

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ import { UserFactory } from "./db/factories/user.factory";
 import MainSeeder from "./db/seeds/main.seeder";
 import { Order } from "./entities/order.entity";
 import { Service } from "./entities/service.entity";
+import { ServiceFactory } from "./db/factories/service.factory";
+import { OrderFactory } from "./db/factories/order.factory";
 
 export const appDBConnect: DataSourceOptions & SeederOptions = {
     type: 'mysql',
@@ -25,5 +27,7 @@ export const appDBConnect: DataSourceOptions & SeederOptions = {
     ],
     factories: [
         UserFactory,
+        ServiceFactory,
+        OrderFactory
     ]
 }

--- a/src/db/factories/order.factory.ts
+++ b/src/db/factories/order.factory.ts
@@ -1,0 +1,23 @@
+import { Faker } from '@faker-js/faker';
+import { setSeederFactory } from 'typeorm-extension';
+import { Order } from '../../entities/order.entity';
+import { EOrderStatus } from '../../interfaces/EOrderStatus.enum';
+
+export const OrderFactory = setSeederFactory(Order, (faker: Faker) => {
+    const order = new Order();
+    order.service_id = Math.random() < 0.5 ? 1 : 2;
+    order.address = faker.location.streetAddress();
+    order.performers_quantity = Math.floor(Math.random() * 20) + 1;
+
+    const currentDate = new Date();
+    const randomDays = Math.floor(Math.random() * 24) + 7;
+    const generatedDate = new Date(currentDate.getTime() + randomDays * 24 * 60 * 60 * 1000);
+    order.order_data = generatedDate.toISOString();
+
+    order.lat = faker.location.latitude();
+    order.lng = faker.location.longitude();
+
+    order.status = EOrderStatus.IN_PROGRESS;
+
+    return order;
+})

--- a/src/db/factories/service.factory.ts
+++ b/src/db/factories/service.factory.ts
@@ -1,0 +1,8 @@
+import { Faker } from '@faker-js/faker';
+import { setSeederFactory } from 'typeorm-extension';
+import { Service } from '../../entities/service.entity';
+
+export const ServiceFactory = setSeederFactory(Service, (faker: Faker) => {
+    const service = new Service();
+    return service;
+})

--- a/src/db/factories/user.factory.ts
+++ b/src/db/factories/user.factory.ts
@@ -7,9 +7,10 @@ const roles = [ERole.admin, ERole.manager, ERole.customer, ERole.performer];
 
 export const UserFactory = setSeederFactory(User, (faker: Faker) => {
     const user = new User();
-    user.phone = faker.number.int(9).toString();
-    user.display_name = faker.person.firstName();
+    user.phone = faker.number.int({ min: 7000000000, max: 7999999999 }).toString();
+    user.display_name = `${faker.person.firstName()} ${faker.person.lastName()}`;
     user.password = 'password';
+    user.hashPassword();
     user.role = faker.helpers.arrayElement(roles);
     return user;
 })

--- a/src/db/seeds/main.seeder.ts
+++ b/src/db/seeds/main.seeder.ts
@@ -2,13 +2,53 @@ import { DataSource } from 'typeorm';
 import { Seeder, SeederFactoryManager } from 'typeorm-extension';
 import { User } from '../../entities/user.entity';
 import { ERole } from '../../interfaces/ERole.enum';
+import { Service } from '../../entities/service.entity';
+import { Order } from '../../entities/order.entity';
+import { IUser } from '../../interfaces/IUser.interface';
+import { IService } from '../../interfaces/IService.interface';
+
+const managers: IUser[] = [];
+const customers: IUser[] = [];
+const performers: IUser[] = [];
+const services: IService[] = [];
 
 export default class MainSeeder implements Seeder {
     public async run(dataSource: DataSource, factoryManager: SeederFactoryManager): Promise<void> {
         const userFactory = factoryManager.get(User);
-        await userFactory.save({ role: ERole.admin });
-        await userFactory.save({ role: ERole.manager });
-        await userFactory.saveMany(2, { role: ERole.customer });
-        await userFactory.saveMany(4, { role: ERole.performer });
+        const admin = await userFactory.save({ role: ERole.admin });
+        managers.push(admin);
+
+        const manager1 = await userFactory.save({ role: ERole.manager });
+        managers.push(manager1);
+        const { phone, display_name } = manager1;
+
+        const newManagers = await userFactory.saveMany(3, { role: ERole.manager });
+        newManagers.forEach(manager => managers.push(manager));
+
+        const customer1 = await userFactory.save({ phone, display_name, role: ERole.customer });
+        customers.push(customer1);
+
+        const newCustomers = await userFactory.saveMany(4, { role: ERole.customer });
+        newCustomers.forEach(customer => customers.push(customer));
+
+        const performer1 = await userFactory.save({ phone, display_name, role: ERole.performer });
+        performers.push(performer1);
+
+        const newPerformers = await userFactory.saveMany(6, { role: ERole.performer });
+        newPerformers.forEach(performer => performers.push(performer));
+
+        const serviceFactory = factoryManager.get(Service);
+        const heaver = await serviceFactory.save({ name: "Грузчик", price: 5000 });
+        const freightTransport = await serviceFactory.save({ name: "Грузовой транспорт", price: 8000 });
+        services.push(heaver);
+        services.push(freightTransport);
+        const orderFactory = factoryManager.get(Order);
+
+        for (let i = 0; i < 100; i++) {
+            await orderFactory.save({
+                customer_id: customers[Math.floor(Math.random() * customers.length)].id,
+                manager_id: managers[Math.floor(Math.random() * managers.length)].id,
+            })
+        }
     }
 }

--- a/src/interfaces/IOrderList.interface.ts
+++ b/src/interfaces/IOrderList.interface.ts
@@ -1,0 +1,8 @@
+import { IOrder } from "./IOrder.interface";
+
+export interface IOrderList {
+    orders: IOrder[];
+    totalItems: number;
+    totalPages: number;
+    links: Record<string, string | null>;
+}

--- a/src/repositories/order.repository.ts
+++ b/src/repositories/order.repository.ts
@@ -4,14 +4,36 @@ import { Order } from '../entities/order.entity';
 import { IOrder } from '../interfaces/IOrder.interface';
 import { EOrderStatus } from '../interfaces/EOrderStatus.enum';
 import { OrderDto } from '../dto/order.dto';
+import { IOrderList } from '../interfaces/IOrderList.interface';
 
 export class OrderRepository extends Repository<Order> {
     constructor() {
         super(Order, appDataSource.createEntityManager());
     }
 
-    async getOrders(): Promise<IOrder[]> {
-        return await this.find();
+    async getOrders(offset: number, limit: number): Promise<IOrderList> {
+        const totalItems = await this.count();
+        const orders = await this.find({ skip: offset, take: limit });
+        const links = this.getLinks(totalItems, offset, limit);
+        return { orders, totalItems, totalPages: Math.ceil(totalItems / limit), links };
+    }
+
+    getLinks(totalItems: number, offset: number, limit: number, manager: number | null = null, customer: number | null = null, performer: number | null = null): Record<string, string | null> {
+        const totalPages = Math.ceil(totalItems / limit);
+        const linkStr = `/order?${manager ? `manager=${manager}&` : ''}${customer ? `customer=${customer}&` : ''}${performer ? `performer=${performer}&` : ''}`;
+        const links: Record<string, string | null> = {
+            next: offset + limit < totalItems ? `${linkStr}offset=${offset + limit}&limit=${limit}` : null,
+            prev: offset - limit >= 0 ? `${linkStr}offset=${offset - limit}&limit=${limit}` : null,
+            first: `${linkStr}offset=0&limit=${limit}`,
+            last: `${linkStr}offset=${(totalPages - 1) * limit}&limit=${limit}`
+        };
+
+        for (let page = 1; page <= totalPages; page++) {
+            const pageOffset = (page - 1) * limit;
+            links[`page${page}`] = `${linkStr}offset=${pageOffset}&limit=${limit}`;
+        }
+
+        return links;
     }
 
     async getOrderById(id: number): Promise<IOrder | null> {
@@ -20,23 +42,39 @@ export class OrderRepository extends Repository<Order> {
         })
     }
 
-    async getOrdersByManager(manager_id: number): Promise<IOrder[]> {
-        return await this.find({
-            where: { manager_id }
+    async getOrdersByManager(manager_id: number, offset: number, limit: number): Promise<IOrderList> {
+        const totalItems = await this.count({ where: { manager_id } });
+        const orders = await this.find({
+            where: { manager_id },
+            skip: offset, take: limit
         });
+        const links = this.getLinks(totalItems, offset, limit, manager_id);
+        return { orders, totalItems, totalPages: Math.ceil(totalItems / limit), links };
     }
 
-    async getOrdersByCustomer(customer_id: number): Promise<IOrder[]> {
-        return await this.find({
-            where: { customer_id }
+    async getOrdersByCustomer(customer_id: number, offset: number, limit: number): Promise<IOrderList> {
+        const totalItems = await this.count({ where: { customer_id } });
+        const orders = await this.find({
+            where: { customer_id },
+            skip: offset, take: limit
         });
+        const links = this.getLinks(totalItems, offset, limit, null, customer_id);
+        return { orders, totalItems, totalPages: Math.ceil(totalItems / limit), links };
     }
 
-    async getOrdersByPerformer(performer_id: number): Promise<IOrder[]> {
-        return await this.createQueryBuilder("order")
+    async getOrdersByPerformer(performer_id: number, offset: number, limit: number): Promise<IOrderList> {
+        const totalItems = await this.createQueryBuilder("order")
             .innerJoin("performer_order", "po", "po.order_id = order.id")
             .where("po.performer_id = :performer_id", { performer_id })
+            .getCount();
+        const orders = await this.createQueryBuilder("order")
+            .innerJoin("performer_order", "po", "po.order_id = order.id")
+            .where("po.performer_id = :performer_id", { performer_id })
+            .skip(offset)
+            .take(limit)
             .getMany();
+        const links = this.getLinks(totalItems, offset, limit, null, null, performer_id);
+        return { orders, totalItems, totalPages: Math.ceil(totalItems / limit), links };
     }
 
     async createOrder(data: OrderDto): Promise<IOrder> {

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -19,6 +19,12 @@ export class UserRepository extends Repository<User> {
         })
     }
 
+    async getUserByIdAndRole(id: number, role: ERole): Promise<IUser | null> {
+        return await this.findOne({
+            where: { id, role }
+        })
+    }
+
     async getUserByPhoneAndRole(phone: string, role: ERole): Promise<IUser | null> {
         return await this.findOne({
             where: { phone, role }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -15,6 +15,14 @@ export class AuthService {
         this.repository = new UserRepository();
     }
 
+    getUserById = async (id: number): Promise<IUser | null> => {
+        return await this.repository.getUserById(id);
+    }
+
+    getUserByIdAndRole = async (id: number, role: ERole): Promise<IUser | null> => {
+        return await this.repository.getUserByIdAndRole(id, role);
+    }
+
     getUserByPhoneAndRole = async (phone: string, role: ERole): Promise<IUser | null> => {
         return await this.repository.getUserByPhoneAndRole(phone, role);
     }

--- a/src/services/order.service.ts
+++ b/src/services/order.service.ts
@@ -2,6 +2,7 @@ import { OrderRepository } from '../repositories/order.repository';
 import { IOrder } from '../interfaces/IOrder.interface';
 import { EOrderStatus } from '../interfaces/EOrderStatus.enum';
 import { OrderDto } from '../dto/order.dto';
+import { IOrderList } from '../interfaces/IOrderList.interface';
 
 export class OrderService {
     private repository: OrderRepository;
@@ -10,24 +11,24 @@ export class OrderService {
         this.repository = new OrderRepository();
     }
 
-    getOrders = async (): Promise<IOrder[]> => {
-        return await this.repository.getOrders();
+    getOrders = async (offset: number, limit: number): Promise<IOrderList> => {
+        return await this.repository.getOrders(offset, limit);
     }
 
     getOrderById = async (order_id: number): Promise<IOrder | null> => {
         return await this.repository.getOrderById(order_id);
     }
 
-    getOrdersByManager = async (manager_id: number): Promise<IOrder[]> => {
-        return await this.repository.getOrdersByManager(manager_id);
+    getOrdersByManager = async (manager_id: number, offset: number, limit: number): Promise<IOrderList> => {
+        return await this.repository.getOrdersByManager(manager_id, offset, limit);
     }
 
-    getOrdersByCustomer = async (customer_id: number): Promise<IOrder[]> => {
-        return await this.repository.getOrdersByCustomer(customer_id);
+    getOrdersByCustomer = async (customer_id: number, offset: number, limit: number): Promise<IOrderList> => {
+        return await this.repository.getOrdersByCustomer(customer_id, offset, limit);
     }
 
-    getOrdersByPerformer = async (performer_id: number): Promise<IOrder[]> => {
-        return await this.repository.getOrdersByPerformer(performer_id);
+    getOrdersByPerformer = async (performer_id: number, offset: number, limit: number): Promise<IOrderList> => {
+        return await this.repository.getOrdersByPerformer(performer_id, offset, limit);
     }
 
     createOrder = async (orderDto: OrderDto): Promise<IOrder | null> => {

--- a/src/services/redis.service.ts
+++ b/src/services/redis.service.ts
@@ -1,6 +1,6 @@
 import { createClient } from "redis"
 
-class Redisservice {
+class RedisService {
     public client = createClient();
     constructor() {
         this.init().then(() => {
@@ -13,4 +13,4 @@ class Redisservice {
     }
 }
 
-export const redisClient = new Redisservice().client
+export const redisClient = new RedisService().client


### PR DESCRIPTION
при вводе команды
```
npm run seed 
```
таблица user будет заполнена одним админом, 4-мя менеджерами, 5 заказчиками и 7 исполнителями(среди них один телефон будет с тремя ролями),
таблица service будет заполнена двумя услугами,
таблица order будет заполнена 100-ей заказов с разным сочетанием manager_id и customer_id. Дата заказа будет распределена в промежутке ОТ через неделю ДО через месяц

Запросы можно выполнять в виде 
```
/order?manager=2&customer=6&offset=40&limit=20,
```
где manager - manager_id заказа,
customer - customer _id заказа,
offset - количество заказов, которые мы пропускаем(считается, что оно содержится на предыдущих страницах)
limit - максимальное количество заказов, которые мы выводим на одну страницу.

В перспективе все готово для того, чтобы работал поиск и по performer_id, но нужна промежуточная сущность performerOrder.